### PR TITLE
Update team member website URLs

### DIFF
--- a/docs/team/alumni/external_mentees/Xujia Liu.md
+++ b/docs/team/alumni/external_mentees/Xujia Liu.md
@@ -2,6 +2,6 @@
 people: Xujia Liu
 surname: Liu
 school: University of Nottingham Ningbo China
-website: https://www.xiaohongshu.com/user/profile/66ee6a82000000001e0060f4
+website: https://none-momo.github.io
 year: 2025
 ---

--- a/docs/team/current_students/Yuchen Yan.md
+++ b/docs/team/current_students/Yuchen Yan.md
@@ -2,5 +2,5 @@
 people: Yuchen Yan
 surname: Yan
 degree: BEng Digital Media Technology
-website: https://chiran.top/
+website: https://blog.chiran.top/
 ---


### PR DESCRIPTION
Update website front-matter for two team members:
- docs/team/alumni/external_mentees/Xujia Liu.md: replace Xiaohongshu link with https://none-momo.github.io
- docs/team/current_students/Yuchen Yan.md: change https://chiran.top/ to https://blog.chiran.top/ These changes correct/update the personal website URLs in the team profiles.